### PR TITLE
chore: fix export type

### DIFF
--- a/src/Themes/index.ts
+++ b/src/Themes/index.ts
@@ -9,5 +9,5 @@ export {DefaultFontSize, DefaultSpaceSize} from './size';
 export {DefaultColorTheme} from './colors';
 export {DefaultTheme} from './theme';
 // typings
-export type {Color} from './colors';
-export type {FontSize, SpaceSize} from './size';
+export {Color} from './colors';
+export {FontSize, SpaceSize} from './size';


### PR DESCRIPTION
remove type export to support older versions of typescript